### PR TITLE
Ios Parsers for differents commands

### DIFF
--- a/parsers/ios/ios_show_cdp.yml
+++ b/parsers/ios/ios_show_cdp.yml
@@ -1,0 +1,72 @@
+---
+# IOS Show CDP neighbor Parser
+#
+# Command: show cdp neighbor detail
+#
+# Example Command Output:
+# ----------------------
+#
+# spine1# show cdp nei detail
+# ----------------------------------------
+# Device ID:cumulus
+#
+# Interface address(es):
+# Platform: Linux, Capabilities: Router Switch
+# Interface: mgmt0, Port ID (outgoing port): swp2
+# Holdtime: 111 sec
+#
+# Version:
+# Cumulus Linux version 3.3.2
+#
+# Advertisement Version: 2
+#
+#
+#Example Playbook
+#-----------------
+# - hosts: localhost
+#   connection: local
+#   tasks:
+#     - name: get show cdp nei output
+#       ios_command:
+#         commands:
+#           - show cdp neighbors detail
+#       register: cdp_output
+#
+#     - name: create fact based on CDP neighbor details
+#       set_fact:
+#           ios_cdp: "{{ cdp_output.stdout[0] | parse_cli('./parsers/ios/ios_show_cdp.yml') }}"
+#
+#
+# Schema Output
+# -------------
+#
+# ok: [cisco01] => {
+#     "ansible_facts": {
+#         "neighbors": [
+#             {
+#                 "local_interface": "mgmt0",
+#                 "remote_hostname": "cumulus",
+#                 "remote_interface": "swp2"
+#             }
+#         ]
+#     },
+#     "changed": false,
+#     "failed": false
+# }
+#
+#
+vars:
+  neighbor:
+    local_interface: "{{ item[1].local_iface }}"
+    remote_hostname: "{{ item[0].rmt_host }}"
+    remote_interface: "{{ item[2].rmt_iface }}"
+
+keys:
+  neighbors:
+    value: "{{ neighbor }}"
+    start_block: "^----.+$"
+    end_block: "^advertisement.+$"
+    items:
+      - "Device ID: (?P<rmt_host>.+)\\s+Entry"
+      - "Interface: (?P<local_iface>\\S+),"
+      - "Port ID.+:\\s+(?P<rmt_iface>.+)\\s+Holdtime"

--- a/parsers/ios/ios_show_int_switchport.yml
+++ b/parsers/ios/ios_show_int_switchport.yml
@@ -1,0 +1,116 @@
+---
+# IOS Show interfaces switchport Parser
+#
+# Command: show interfaces switchport
+#
+#
+# Example Command Output:
+# ----------------------
+# cisco1#show interfaces switchport
+# Name: Gi1/0/1
+# Switchport: Enabled
+# Administrative Mode: static access
+# Operational Mode: down
+# Administrative Trunking Encapsulation: dot1q
+# Negotiation of Trunking: Off
+# Access Mode VLAN: 40 (Tech)
+# Trunking Native Mode VLAN: 1 (default)
+# Administrative Native VLAN tagging: enabled
+# Voice VLAN: 6 (VoIP)
+# Administrative private-vlan host-association: none
+# Administrative private-vlan mapping: none
+# Administrative private-vlan trunk native VLAN: none
+# Administrative private-vlan trunk Native VLAN tagging: enabled
+# Administrative private-vlan trunk encapsulation: dot1q
+# Administrative private-vlan trunk normal VLANs: none
+# Administrative private-vlan trunk associations: none
+# Administrative private-vlan trunk mappings: none
+# Operational private-vlan: none
+# Trunking VLANs Enabled: ALL
+# Pruning VLANs Enabled: 2-1001
+# Capture Mode Disabled
+# Capture VLANs Allowed: ALL
+#
+# Protected: false
+# Unknown unicast blocked: disabled
+# Unknown multicast blocked: disabled
+# Appliance trust: none
+#
+
+#Example Playbook
+#-----------------
+# - hosts: localhost
+#   connection: local
+#   tasks:
+# - name: get show interface switchport
+#   ios_command:
+#     commands:
+#       - show interfaces switchport
+#   register: switchport_output
+#
+# - name: create fact based on switchport_output
+#   set_fact:
+#     ios_switchport: "{{ switchport_output.stdout[0] | parse_cli('cli_filters/ios/ios_show_int_switchport.yml') }}"
+#
+# Schema Output
+# -------------
+#
+# ok: [cisco01] => {
+#     "ansible_facts": {
+#         "ios_switchport": [
+#         {
+#             "access_vlan": 100,
+#             "admin_mode": "static access",
+#             "interface": "FastEthernet0/1",
+#             "negotiation": "Off",
+#             "operational_mode": "static access",
+#             "pruning_vlans": "2-1001",
+#             "status": "Enabled",
+#             "trunking_native_vlan": 1,
+#             "trunking_vlans": "ALL",
+#             "voice_vlan": null
+#         },
+#         {
+#             "access_vlan": 100,
+#             "admin_mode": "static access",
+#             "interface": "FastEthernet0/2",
+#             "negotiation": "Off",
+#             "operational_mode": "down",
+#             "pruning_vlans": "2-1001",
+#             "status": "Enabled",
+#             "trunking_native_vlan": 1,
+#             "trunking_vlans": "ALL",
+#             "voice_vlan": null
+#         }
+#     ]
+# }
+#
+vars:
+  switchport:
+    interface: "{{ item[0].interface | replace('Fa', 'FastEthernet') | replace('Gi', 'GigabitEthernet') | replace('Te', 'TenGigabitEthernet') }}"
+    status: "{{ item[1].status }}"
+    admin_mode: "{{ item[2].admin_mode }}"
+    operational_mode: "{{ item[3].operational_mode }}"
+    negotiation: "{{ item[4].negotiation }}"
+    access_vlan: "{{ item[5].access_vlan }}"
+    trunking_native_vlan: "{{ item[6].trunking_native_vlan }}"
+    voice_vlan: "{{ item[7].voice_vlan }}"
+    trunking_vlans: "{{ item[8].trunking_vlans }}"
+    pruning_vlans: "{{ item[9].pruning_vlans }}"
+
+keys:
+  switchports:
+    value: "{{ switchport }}"
+    start_block: "^Name.+$"
+    end_block: "^Capture Mode.+$"
+    items:
+      - "Name: (?P<interface>.+)\n"
+      - "Switchport: (?P<status>.+)\n"
+      - "Administrative Mode: (?P<admin_mode>.+)\n"
+      - "Operational Mode: (?P<operational_mode>.+)\n"
+      - "Negotiation of Trunking: (?P<negotiation>.+)\n"
+      - "Access Mode VLAN: (?P<access_vlan>\\d+).*\n"
+      - "Trunking Native Mode VLAN: (?P<trunking_native_vlan>\\d+).*\n"
+      - "Voice VLAN: (?P<voice_vlan>\\d+).*\n"
+      - "Trunking VLANs Enabled: (?P<trunking_vlans>.+)\n"
+      - "Pruning VLANs Enabled: (?P<pruning_vlans>.+)\n"

--- a/parsers/ios/ios_show_int_trunk.yml
+++ b/parsers/ios/ios_show_int_trunk.yml
@@ -1,0 +1,65 @@
+---
+# IOS Show interfaces trunk Parser
+#
+# Command: show interfaces trunk
+#
+#
+# Example Command Output:
+# ----------------------
+# cisco1#show interfaces trunk
+#
+# Port        Mode             Encapsulation  Status        Native vlan
+# Gi1/0/49    on               802.1q         trunking      1
+# Te1/0/2     on               802.1q         trunking      1
+#
+# Port        Vlans allowed on trunk
+# Gi1/0/49    1-4094
+# Te1/0/2     1-4094
+#
+# Port        Vlans allowed and active in management domain
+# Gi1/0/49    1-2,4-6,10,20,40,49-51,55-56,60-62,69,80,100,200,210-213,300,310,400,410,902-903,915,920-922
+# Te1/0/2     1-2,4-6,10,20,40,49-51,55-56,60-62,69,80,100,200,210-213,300,310,400,410,902-903,915,920-922
+#
+# Port        Vlans in spanning tree forwarding state and not pruned
+# Gi1/0/49    1-2,4-6,10,20,40,49-51,55-56,60-62,69,80,100,200,210-213,300,310,400,410,902-903,915,920-922
+# Te1/0/2     1,6,10,40,51,400,410
+#
+#Example Playbook
+#-----------------
+# - hosts: localhost
+#   connection: local
+#   tasks:
+# - name: get show interface trunk
+#   ios_command:
+#     commands:
+#       - show interfaces trunk
+#   register: trunk_output
+#
+# - name: create fact based on switchport_output
+#   set_fact:
+#     ios_trunk: "{{ trunk_output.stdout[0] | parse_cli('cli_filters/ios/ios_show_int_trunk.yml') }}"
+#
+# Schema Output
+# -------------
+#
+# ok: [cisco01] => {
+#     "ansible_facts": {
+#         "ios_trunk": [
+#         {
+#             "interface": "FastEthernet0/1"
+#         },
+#         {
+#             "interface": "FastEthernet0/2"
+#         }
+#     ]
+# }
+#
+vars:
+  trunk:
+    interface: "{{ item.interface | replace('Gi', 'GigabitEthernet') | replace('Te', 'TenGigabitEthernet') }}"
+
+keys:
+  trunks:
+    type: list
+    value: "{{ trunk }}"
+    items: "^(?P<interface>[a-zA-Z0-9/]+).*(?P<state>trunking)"


### PR DESCRIPTION
Included:
- show cdp neighbor detail
- show interfaces switchport
- show interfaces trunk

Tested against IOS versions: 15.x and 12.1
